### PR TITLE
🧱 add `tsar-compartment-maintainer-group` and identity user

### DIFF
--- a/secret.enc.yaml
+++ b/secret.enc.yaml
@@ -2,6 +2,9 @@ oci:
     config:
         tenancy_ocid: ENC[AES256_GCM,data:U4I9mmxNih2JWsn8MFwmIXIxIaRKdkPfu4qupEnms/xXqOhIHyALeSxfYxK35FeYSfAKy+SUMURkfz2cMAQXNHtJnEqGHGDx3IBNAi9apQ==,iv:+NOwzhIhFYo3k7YyiUqFlnxtu392Ht99R1JS8+H/e4Y=,tag:w6FhSnce5F63iPkGJJ4tLg==,type:str]
         region: ENC[AES256_GCM,data:dCwAzEd/492d9g==,iv:/IZaA5PSYy+BXcR1ydzdgRTl5/o9Z+Acyx3rZdCr6XE=,tag:kQ2XCLM68+wc2xHfZJEOpw==,type:str]
+    identity-user:
+        leoleo:
+            email: ENC[AES256_GCM,data:BOV6ghFy7RH7ZHlnKjKc9ERitQGgJw==,iv:PghQ2zjV9qRvxHHpTkf/y6Ni79m8BmgWZ2jStGfGD/I=,tag:fh46f3Sz+fWNny8A1B7dKQ==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -17,8 +20,8 @@ sops:
             T0hGTGxyL0VpVkFVYSt5UjYrdU5aM2cKYTzyDVI7sBuCKpCuxXRcaoaDMfb8nVIq
             mCWjNvztIBMhBnsjQWOQQND0ua/06A3id5/BKz5YtiBzCWSXQx9WHg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-08-29T16:16:32Z"
-    mac: ENC[AES256_GCM,data:KixJBpLLQ0AE1p4UxBT+gYNFAg4ipcJqDINZ4Cx0eT+w88YZBNyIeWuCbxlR4d6K3bIe9xzOhuXn34DRWDF7Eb7QRvlpv7EZbOUM5Ay6Xs8Bfk41la3TbiP1RTitbiNhL3ABiHbrt2sqmjKXlX7QTezHEjh9s1/fEQzq6sxaPes=,iv:7NqJMdx03jpIJgqo4khqSnRDG4SInFMjGvR8c8TXejE=,tag:+4uqx6telnNgk8W/NteYrA==,type:str]
+    lastmodified: "2024-08-30T12:20:20Z"
+    mac: ENC[AES256_GCM,data:baCp3zXbfipLpjdkAsp0JdLHnhm5SQauwlbjRthCu7npwEAmE0uLiFXF1/jSKHV+JXIudjotefsobf7oBvpGSUORaBYmmkKijJU46GdTv/BvA2qULijFyRvkM93tbvkGIGCBeyHXQdLP2p0FLQsfRTR3SdipOzB0kNbHM2ZGNRw=,iv:SnrYWQzq3tCro8Ji1fLhXZqXQwt0JaFP8XUdng6ZUXE=,tag:TsOy8UV7S2PaxQM3rhYBxA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.9.0

--- a/terraform/Identity.tf
+++ b/terraform/Identity.tf
@@ -1,5 +1,43 @@
+## compartment
 resource "oci_identity_compartment" "tsar_compartment" {
   compartment_id = data.sops_file.secrets.data["oci.config.tenancy_ocid"]
   description    = "tsar compartment"
   name           = "tsar-compartment"
+}
+
+## identity user
+### https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/identity_user
+resource "oci_identity_user" "user_leoleo" {
+  compartment_id = data.sops_file.secrets.data["oci.config.tenancy_ocid"]
+  description    = "identify user for tsar"
+  name           = "leoleo"
+
+  email = data.sops_file.secrets.data["oci.identity-user.leoleo.email"]
+}
+
+## identity group
+### https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/identity_group
+resource "oci_identity_group" "tsar_compartment_maintainer_group" {
+  #Required
+  compartment_id = data.sops_file.secrets.data["oci.config.tenancy_ocid"]
+  description    = "tsar compartment maintainer group"
+  name           = "tsar-compartment-maintainer-group"
+}
+
+## identity user group membership
+### https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/identity_user_group_membership
+resource "oci_identity_user_group_membership" "tsar_compartment_maintainer_group_membership_leoleo" {
+  group_id = oci_identity_group.tsar_compartment_maintainer_group.id
+  user_id  = oci_identity_user.user_leoleo.id
+}
+
+## identity policy
+### https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/identity_policy
+resource "oci_identity_policy" "tsar_compartment_maintainer_policy" {
+  compartment_id = data.sops_file.secrets.data["oci.config.tenancy_ocid"]
+  description    = "Allow group ${oci_identity_group.tsar_compartment_maintainer_group.name} to manage all-resources in ${oci_identity_compartment.tsar_compartment.name}"
+  name           = "tsar-compartment-maintainer-policy"
+  statements = [
+    "Allow group ${oci_identity_group.tsar_compartment_maintainer_group.name} to manage all-resources in compartment ${oci_identity_compartment.tsar_compartment.name}"
+  ]
 }


### PR DESCRIPTION
# やったこと

- identity user `leoleo`の定義
- identity group `tsar-compartment-maintainer-group`の定義
- identity group `tsar-compartment-maintainer-group`に identity user `leoleo`を追加
- identity policy `tsar-compartment-maintainer-policy`の定義
  -  identity group `tsar-compartment-maintainer-group`に、compartment `tsar-compartment`以下の全てのリソースの`manage`権限を付与